### PR TITLE
IsoRec (Isolated Recovery) for Dorimanx

### DIFF
--- a/sbin/init
+++ b/sbin/init
@@ -16,6 +16,50 @@ $BB mount -t rootfs -o remount,rw rootfs;
 if $BB grep -q bootmode=2 /proc/cmdline; then
 	# recovery mode
 	echo "0" > /proc/sys/kernel/rom_feature_set;
+
+
+	# attempt isorec (isolated recovery) boot
+
+	# make the /dev/block/platform/dw_mmc/by-name/RECOVERY
+	# (/dev/block/mmcblk0p6) partition accessible
+	mknod /dev/block/isorec-mmcblk0p6 b 179 6;
+	mkdir -p /stage1/junk
+
+	# if the raw partition contains valid lzop-compressed data
+	if $BB lzop -dc /dev/block/isorec-mmcblk0p6 > /stage1/isorec.cpio ; then
+		# and if said data is a valid cpio archive
+		if $BB cpio -t < /stage1/isorec.cpio ; then
+
+			# isorec boot
+
+			# unmount everything
+			$BB umount /sys
+			$BB umount /proc
+
+			# move busybox to /stage1
+			$BB mv $BB /stage1/busybox
+			BB=/stage1/busybox
+
+			# remove everything not in /stage1
+			$BB mv /* /stage1/junk
+			$BB rm -rf /stage1/junk
+			$BB rm -f /.*
+
+			# extract the isorec ramdisk
+			$BB cpio -i < /stage1/isorec.cpio
+
+			# remove /stage1 and pass control
+			$BB rm -rf /stage1
+			exec /init
+
+		fi
+	fi
+
+	# clean up for non-isorec boot
+	$BB rm -rf /stage1
+	$BB rm -f /dev/block/isorec-mmcblk0p6
+
+
 	$BB cp /res/images/recovery-icon.png /res/images/icon_clockwork.png;
 	$BB cp -a /recovery.rc /init.rc;
 	mknod /dev/block/mmcblk0p1 b 179 1;


### PR DESCRIPTION
IsoRec aims to be a standard by which the monolithic kernel/recovery binaries
of the S2 family of devices can invoke an alternate recovery optionally flashed
separately by the user.

The alternate recovery is flashed to the RECOVERY partition (/dev/block/mmcblk0p6),
a seemingly vestigial partition without any real use. Only the lzop-compressed,
cpio-formatted recovery ramdrive is stored there; the standard kernel image is
used to run this recovery. The lzop-compressed image of the ramdrive is stored
raw in the RECOVERY partition.

Behavior of patch:
-skip all this if not booting into recovery.
-if the raw recovery partition contains valid lzop-compressed data,
-and if said data is a valid cpio archive,
-then use that cpio archive as the recovery ramdrive;
-else run the recovery bundled with Dorimanx.

More information here:
http://forum.xda-developers.com/galaxy-s2/orig-development/isorec-isolated-recovery-galaxy-s2-t3291176
